### PR TITLE
SDSS-812 Syndication module with enterprise new plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# [Stanford Syndication](https://github.com/SU-SWS/stanford_syndication)
+
+
+Changelog: [Changelog.md](CHANGELOG.md)
+
+Description
+---
+
+This is essentially a webhook trigger to inform the Syndication CMS about new content.
+
+Installation
+---
+
+Install this module like any other. [See Drupal Documentation](https://www.drupal.org/docs/extending-drupal/installing-modules)
+
+Configuration
+---
+
+Configure the desired content types and the access token at `/admin/config/services/syndication`.
+
+
+Contribution / Collaboration
+---
+
+You are welcome to contribute functionality, bug fixes, or documentation to this module. If you would like to suggest a fix or new functionality you may add a new issue to the GitHub issue queue or you may fork this repository and submit a pull request. For more help please see [GitHub's article on fork, branch, and pull requests](https://help.github.com/articles/using-pull-requests)

--- a/config/install/stanford_syndication.settings.yml
+++ b/config/install/stanford_syndication.settings.yml
@@ -1,0 +1,2 @@
+enabled: true
+syndicators: {}

--- a/config/schema/stanford_syndication.data_types.schema.yml
+++ b/config/schema/stanford_syndication.data_types.schema.yml
@@ -1,0 +1,7 @@
+syndicator.plugin:
+  type: mapping
+  label: 'Syndicator'
+  mapping:
+    id:
+      type: string
+      label: 'ID'

--- a/config/schema/stanford_syndication.schema.yml
+++ b/config/schema/stanford_syndication.schema.yml
@@ -1,0 +1,11 @@
+# Schema for the configuration files of the stanford_syndication module.
+stanford_syndication.settings:
+  type: config_object
+  label: Syndication settings
+  mapping:
+    enabled:
+      type: boolean
+      label: Enable the syndication connection.
+    syndicators:
+      type: sequence
+      label: Syndicators settings.

--- a/config/schema/stanford_syndication.schema.yml
+++ b/config/schema/stanford_syndication.schema.yml
@@ -1,4 +1,18 @@
 # Schema for the configuration files of the stanford_syndication module.
+
+syndicator.plugin.stanford_enterprise:
+  type: syndicator.plugin
+  mapping:
+    node_types:
+      type: sequence
+      label: Node Types
+      sequence:
+        type: string
+        label: Node Type
+    webhook:
+      type: string
+      label: Webhook URL
+
 stanford_syndication.settings:
   type: config_object
   label: Syndication settings
@@ -9,3 +23,6 @@ stanford_syndication.settings:
     syndicators:
       type: sequence
       label: Syndicators settings.
+      sequence:
+        type: syndicator.plugin.[id]
+        label: Syndicator settings

--- a/src/Annotation/Syndicator.php
+++ b/src/Annotation/Syndicator.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\stanford_syndication\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines syndicator annotation object.
+ *
+ * @Annotation
+ */
+class Syndicator extends Plugin {
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The human-readable name of the plugin.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $title;
+
+  /**
+   * The description of the plugin.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $description;
+
+}

--- a/src/EventSubscriber/SyndicationEventSubscriber.php
+++ b/src/EventSubscriber/SyndicationEventSubscriber.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\stanford_syndication\EventSubscriber;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\stanford_syndication\Events\SyndicationEntityActionEvent;
+use Drupal\stanford_syndication\Events\SyndicationEvents;
+use Drupal\stanford_syndication\SyndicatorPluginManager;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Stanford Syndication event subscriber.
+ */
+class SyndicationEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Module config settings.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected $syndicationConfig;
+
+  /**
+   * Logger channel service.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
+   * Syndicator plugin manager.
+   *
+   * @var \Drupal\stanford_syndication\SyndicatorPluginManager
+   */
+  protected $pluginManager;
+
+  /**
+   * Constructs the event subscriber object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
+   *   Logger factory service.
+   */
+  public function __construct(ConfigFactoryInterface $configFactory, LoggerChannelFactoryInterface $loggerFactory, SyndicatorPluginManager $pluginManager) {
+    $this->syndicationConfig = $configFactory->get('stanford_syndication.settings');
+    $this->logger = $loggerFactory->get('stanford_syndication');
+    $this->pluginManager = $pluginManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [SyndicationEvents::ENTITY_ACTION => ['onEntityAction']];
+  }
+
+  /**
+   * Syndication action event listener.
+   *
+   * @param \Drupal\stanford_syndication\Events\SyndicationEntityActionEvent $event
+   *   Triggered event.
+   */
+  public function onEntityAction(SyndicationEntityActionEvent $event): void {
+    $plugin_defs = $this->pluginManager->getDefinitions();
+    foreach (array_keys($plugin_defs) as $plugin_id) {
+      try {
+        /** @var \Drupal\stanford_syndication\SyndicatorInterface $plugin */
+        $plugin = $this->pluginManager->createInstance($plugin_id, $this->syndicationConfig->get("syndicators.$plugin_id") ?? []);
+        switch ($event->getAction()) {
+          case SyndicationEntityActionEvent::INSERT_ACTION:
+            $plugin->insert($event->getNode());
+            break;
+
+          case SyndicationEntityActionEvent::UPDATE_ACTION:
+            $plugin->update($event->getNode());
+            break;
+
+          default:
+            $plugin->delete($event->getNode());
+            break;
+        }
+      }
+      catch (\Throwable $e) {
+        $this->logger->error('An error occurred syndicating content: ' . $e->getMessage());
+      }
+    }
+  }
+
+}

--- a/src/Events/SyndicationEntityActionEvent.php
+++ b/src/Events/SyndicationEntityActionEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\stanford_syndication\Events;
+
+use Drupal\Component\EventDispatcher\Event;
+use Drupal\node\NodeInterface;
+
+class SyndicationEntityActionEvent extends Event implements SyndicationEntityActionEventInterface {
+
+  /**
+   * Event constructor.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   Node entity.
+   * @param string $action
+   *   Insert, update, or delete action preformed.
+   */
+  public function __construct(protected NodeInterface $node, protected string $action) {}
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getNode(): NodeInterface {
+    return $this->node;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getAction(): string {
+    return $this->action;
+  }
+
+}

--- a/src/Events/SyndicationEntityActionEventInterface.php
+++ b/src/Events/SyndicationEntityActionEventInterface.php
@@ -6,7 +6,7 @@ use Drupal\node\NodeInterface;
 
 interface SyndicationEntityActionEventInterface {
 
-  const INSERT_ACTION = 'action';
+  const INSERT_ACTION = 'insert';
 
   const UPDATE_ACTION = 'update';
 

--- a/src/Events/SyndicationEntityActionEventInterface.php
+++ b/src/Events/SyndicationEntityActionEventInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\stanford_syndication\Events;
+
+use Drupal\node\NodeInterface;
+
+interface SyndicationEntityActionEventInterface {
+
+  const INSERT_ACTION = 'action';
+
+  const UPDATE_ACTION = 'update';
+
+  const DELETE_ACTION = 'delete';
+
+  /**
+   * Node object during CRUD.
+   *
+   * @return \Drupal\node\NodeInterface
+   */
+  public function getNode(): NodeInterface;
+
+  /**
+   * Insert, update or delete action.
+   *
+   * @return string
+   */
+  public function getAction(): string;
+
+}

--- a/src/Events/SyndicationEvents.php
+++ b/src/Events/SyndicationEvents.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Drupal\stanford_syndication\Events;
+
+/**
+ * Syndication events.
+ */
+final class SyndicationEvents {
+
+  const ENTITY_ACTION = 'stanford_syndication.entity_action';
+
+}

--- a/src/Form/SyndicationSettings.php
+++ b/src/Form/SyndicationSettings.php
@@ -102,14 +102,15 @@ class SyndicationSettings extends ConfigFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $settings = $this->config('stanford_syndication.settings')
-      ->set('enabled', $form_state->getValue('enabled'));
+      ->set('enabled', $form_state->getValue('enabled'))
+      ->set('syndicators', []);
 
     /** @var \Drupal\stanford_syndication\SyndicatorInterface $plugin */
     foreach ($form_state->get('syndicators') as $plugin_id => $plugin) {
       $plugin_form_state = SubformState::createForSubform($form['syndicators'][$plugin_id], $form, $form_state);
       $plugin->submitConfigurationForm($form['syndicators'][$plugin_id], $plugin_form_state);
-
-      if ($config = $plugin->getConfiguration()) {
+      $config = $plugin->getConfiguration();
+      if (array_filter($config)) {
         $config['id'] = $plugin_id;
         $settings->set("syndicators.$plugin_id", $config);
       }

--- a/src/Form/SyndicationSettings.php
+++ b/src/Form/SyndicationSettings.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Drupal\stanford_syndication\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\stanford_syndication\SyndicatorPluginManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Form\SubformState;
+
+/**
+ * Configure stanford_syndication settings for this site.
+ */
+class SyndicationSettings extends ConfigFormBase {
+
+  /**
+   * Constructs a \Drupal\system\ConfigFormBase object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, protected StateInterface $state, protected EntityTypeManagerInterface $entityTypeManager, protected SyndicatorPluginManager $syndicatorPluginManagher) {
+    parent::__construct($config_factory);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('state'),
+      $container->get('entity_type.manager'),
+      $container->get('plugin.manager.syndicator')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'stanford_syndication_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['stanford_syndication.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $defaults = $this->config('stanford_syndication.settings')->getRawData();
+    $form['enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable connection'),
+      '#default_value' => $defaults['enabled'] ?? TRUE,
+    ];;
+    $form['syndicators_tabs'] = [
+      '#type' => 'vertical_tabs',
+      '#title' => $this->t('Syndicators'),
+      '#tree' => TRUE,
+    ];
+    $form['syndicators'] = ['#tree' => TRUE];
+
+    foreach ($this->getSyndicatorPlugins($defaults['syndicators'] ?? []) as $plugin) {
+      $plugin_form = [];
+      $plugin_form_state = SubformState::createForSubform($plugin_form, $form, $form_state);
+      /** @var \Drupal\stanford_syndication\SyndicatorInterface $plugin */
+      $form['syndicators'][$plugin->getPluginId()] = [
+        '#type' => 'details',
+        '#title' => $plugin->label(),
+        '#group' => 'syndicators_tabs',
+        ...$plugin->buildConfigurationForm($plugin_form, $plugin_form_state),
+      ];
+
+      $form_state->set(['syndicators', $plugin->getPluginId()], $plugin);
+    }
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    foreach ($form_state->get('syndicators') as $plugin_id => $plugin) {
+      $plugin_form_state = SubformState::createForSubform($form['syndicators'][$plugin_id], $form, $form_state);
+      $plugin->validateConfigurationForm($form['syndicators'][$plugin_id], $plugin_form_state);
+    }
+    parent::validateForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $settings = $this->config('stanford_syndication.settings')
+      ->set('enabled', $form_state->getValue('enabled'));
+
+    /** @var \Drupal\stanford_syndication\SyndicatorInterface $plugin */
+    foreach ($form_state->get('syndicators') as $plugin_id => $plugin) {
+      $plugin_form_state = SubformState::createForSubform($form['syndicators'][$plugin_id], $form, $form_state);
+      $plugin->submitConfigurationForm($form['syndicators'][$plugin_id], $plugin_form_state);
+
+      if ($config = $plugin->getConfiguration()) {
+        $settings->set("syndicators.$plugin_id", $config);
+      }
+    }
+    $settings->save();
+    parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * Get the syndication plugins with their applicable configurations.
+   *
+   * @return \Drupal\stanford_syndication\SyndicatorInterface[]
+   *   Keyed array of plugins.
+   */
+  protected function getSyndicatorPlugins($syndicators_configs) {
+    $plugin_defs = $this->syndicatorPluginManagher->getDefinitions();
+    $plugins = [];
+    foreach (array_keys($plugin_defs) as $plugin_id) {
+      $plugins[] = $this->syndicatorPluginManagher->createInstance($plugin_id, $syndicators_configs[$plugin_id] ?? []);
+    }
+    return $plugins;
+  }
+
+}

--- a/src/Form/SyndicationSettings.php
+++ b/src/Form/SyndicationSettings.php
@@ -110,6 +110,7 @@ class SyndicationSettings extends ConfigFormBase {
       $plugin->submitConfigurationForm($form['syndicators'][$plugin_id], $plugin_form_state);
 
       if ($config = $plugin->getConfiguration()) {
+        $config['id'] = $plugin_id;
         $settings->set("syndicators.$plugin_id", $config);
       }
     }

--- a/src/Plugin/Syndicator/StanfordEnterprise.php
+++ b/src/Plugin/Syndicator/StanfordEnterprise.php
@@ -105,14 +105,22 @@ class StanfordEnterprise extends SyndicatorPluginBase implements ContainerFactor
    * {@inheritDoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $token = $form_state->getValue('access_token');
+    $form_state->unsetValue('access_token');
+    if(empty($token)){
+      $this->state->delete('stanford_enterprise.token');
+    }
+    else {
+      $this->state->set('stanford_enterprise.token', $token);
+    }
+
     $chosen_types = array_values(array_filter($form_state->getValue('node_types')));
+    $form_state->setValue('node_types', $chosen_types);
     if (empty($chosen_types)) {
       $this->setConfiguration([]);
       return;
     }
-    $this->state->set('stanford_enterprise.token', $form_state->getValue('access_token'));
-    $form_state->unsetValue('access_token');
-    $form_state->setValue('node_types', $chosen_types);
+
     parent::submitConfigurationForm($form, $form_state);
   }
 

--- a/src/Plugin/Syndicator/StanfordEnterprise.php
+++ b/src/Plugin/Syndicator/StanfordEnterprise.php
@@ -95,7 +95,7 @@ class StanfordEnterprise extends SyndicatorPluginBase implements ContainerFactor
     $element['access_token'] = [
       '#type' => 'textfield',
       '#title' => $this->t('API Access Token'),
-      '#default_value' => $this->state->get('stanford_syndication.token'),
+      '#default_value' => $this->state->get('stanford_enterprise.token'),
     ];
 
     return $element;
@@ -105,7 +105,7 @@ class StanfordEnterprise extends SyndicatorPluginBase implements ContainerFactor
    * {@inheritDoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
-    $this->state->set('stanford_syndication.token', $form_state->getValue('access_token'));
+    $this->state->set('stanford_enterprise.token', $form_state->getValue('access_token'));
     $form_state->unsetValue('access_token');
     $form_state->setValue('node_types', array_values(array_filter($form_state->getValue('node_types'))));
     parent::submitConfigurationForm($form, $form_state);
@@ -115,10 +115,11 @@ class StanfordEnterprise extends SyndicatorPluginBase implements ContainerFactor
    * {@inheritDoc}
    */
   public function insert(NodeInterface $node): void {
+    $access_token =  $this->state->get('stanford_enterprise.token');
     if (
       !in_array($node->bundle(), $this->getConfiguration()['node_types']) ||
       !$this->getConfiguration()['webhook'] ||
-      !$this->getConfiguration()['access_token']
+      !$access_token
     ) {
       return;
     }
@@ -126,7 +127,7 @@ class StanfordEnterprise extends SyndicatorPluginBase implements ContainerFactor
     $options = [
       'timeout' => 5,
       'headers' => [
-        'X-Webhook-Token' => $this->state->get('stanford_syndication.token'),
+        'X-Webhook-Token' => $this->state->get('stanford_enterprise.token'),
       ],
       'body' => json_encode([
         'cms_type' => 'Drupal 9',

--- a/src/Plugin/Syndicator/StanfordEnterprise.php
+++ b/src/Plugin/Syndicator/StanfordEnterprise.php
@@ -84,7 +84,7 @@ class StanfordEnterprise extends SyndicatorPluginBase implements ContainerFactor
     $element['node_types'] = [
       '#type' => 'checkboxes',
       '#title' => $this->t('Node Types'),
-      '#default_value' => $this->getConfiguration()['node_types'],
+      '#default_value' => $this->getConfiguration()['node_types'] ?? [],
       '#options' => $node_types,
     ];
     $element['webhook'] = [
@@ -105,9 +105,14 @@ class StanfordEnterprise extends SyndicatorPluginBase implements ContainerFactor
    * {@inheritDoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $chosen_types = array_values(array_filter($form_state->getValue('node_types')));
+    if (empty($chosen_types)) {
+      $this->setConfiguration([]);
+      return;
+    }
     $this->state->set('stanford_enterprise.token', $form_state->getValue('access_token'));
     $form_state->unsetValue('access_token');
-    $form_state->setValue('node_types', array_values(array_filter($form_state->getValue('node_types'))));
+    $form_state->setValue('node_types', $chosen_types);
     parent::submitConfigurationForm($form, $form_state);
   }
 
@@ -115,7 +120,7 @@ class StanfordEnterprise extends SyndicatorPluginBase implements ContainerFactor
    * {@inheritDoc}
    */
   public function insert(NodeInterface $node): void {
-    $access_token =  $this->state->get('stanford_enterprise.token');
+    $access_token = $this->state->get('stanford_enterprise.token');
     if (
       !in_array($node->bundle(), $this->getConfiguration()['node_types']) ||
       !$this->getConfiguration()['webhook'] ||

--- a/src/Plugin/Syndicator/StanfordEnterprise.php
+++ b/src/Plugin/Syndicator/StanfordEnterprise.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Drupal\stanford_syndication\Plugin\Syndicator;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\node\NodeInterface;
+use Drupal\stanford_syndication\SyndicatorPluginBase;
+use GuzzleHttp\ClientInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Plugin implementation for Enterprise News.
+ *
+ * @Syndicator(
+ *   id = "stanford_enterprise",
+ *   label = @Translation("Stanford Enterprise News"),
+ *   description = @Translation("News Syndication webhook.")
+ * )
+ */
+class StanfordEnterprise extends SyndicatorPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Current site domain.
+   *
+   * @var string
+   */
+  protected string $domain;
+
+  /**
+   * Configured site name.
+   *
+   * @var string
+   */
+  protected string $siteName;
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('http_client'),
+      $container->get('state'),
+      $container->get('entity_type.manager'),
+      $container->get('request_stack'),
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, protected ClientInterface $client, protected StateInterface $state, protected EntityTypeManagerInterface $entityTypeManager, RequestStack $requestStack, ConfigFactoryInterface $configFactory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->domain = $requestStack->getCurrentRequest()->getHost();
+    $this->siteName = $configFactory->get('system.site')->get('name');
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function defaultConfiguration() {
+    return ['webhook' => '', 'node_types' => []];
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $element = parent::buildConfigurationForm($form, $form_state);
+    $node_types = [];
+    foreach ($this->entityTypeManager->getStorage('node_type')
+      ->loadMultiple() as $id => $type) {
+      $node_types[$id] = $type->label();
+    }
+
+    $element['node_types'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Node Types'),
+      '#default_value' => $this->getConfiguration()['node_types'],
+      '#options' => $node_types,
+    ];
+    $element['webhook'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Webhook URL'),
+      '#default_value' => $this->getConfiguration()['webhook'],
+    ];
+    $element['access_token'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('API Access Token'),
+      '#default_value' => $this->state->get('stanford_syndication.token'),
+    ];
+
+    return $element;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->state->set('stanford_syndication.token', $form_state->getValue('access_token'));
+    $form_state->unsetValue('access_token');
+    $form_state->setValue('node_types', array_values(array_filter($form_state->getValue('node_types'))));
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function insert(NodeInterface $node): void {
+    if (
+      !in_array($node->bundle(), $this->getConfiguration()['node_types']) ||
+      !$this->getConfiguration()['webhook'] ||
+      !$this->getConfiguration()['access_token']
+    ) {
+      return;
+    }
+
+    $options = [
+      'timeout' => 5,
+      'headers' => [
+        'X-Webhook-Token' => $this->state->get('stanford_syndication.token'),
+      ],
+      'body' => json_encode([
+        'cms_type' => 'Drupal 9',
+        'domain' => $this->domain,
+        'site_name' => $this->siteName,
+        'content_type' => $node->bundle(),
+        'type' => 'teaser',
+        'id' => $node->uuid(),
+      ]),
+    ];
+    $this->client->request('POST', $this->getConfiguration()['webhook'], $options);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function update(NodeInterface $node): void {
+    $this->insert($node);
+  }
+
+}
+

--- a/src/SyndicatorInterface.php
+++ b/src/SyndicatorInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\stanford_syndication;
+
+use Drupal\Component\Plugin\ConfigurableInterface;
+use Drupal\Component\Plugin\PluginInspectionInterface;
+use Drupal\Core\Plugin\PluginFormInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Interface for syndicator plugins.
+ */
+interface SyndicatorInterface extends PluginFormInterface, PluginInspectionInterface, ConfigurableInterface {
+
+  /**
+   * Returns the label for the plugin.
+   *
+   * @return string
+   *   The plugin label.
+   */
+  public function label(): string;
+
+  /**
+   * Act on the insert of a new node.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   Node entity.
+   */
+  public function insert(NodeInterface $node): void;
+
+  /**
+   * Act on the update of a new node.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   Node entity.
+   */
+  public function update(NodeInterface $node): void;
+
+  /**
+   * Act on the deletion of a node.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   Node entity.
+   */
+  public function delete(NodeInterface $node): void;
+
+}

--- a/src/SyndicatorPluginBase.php
+++ b/src/SyndicatorPluginBase.php
@@ -5,7 +5,7 @@ namespace Drupal\stanford_syndication;
 use Drupal\Component\Plugin\PluginBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
-use Drupal\shs\StringTranslationTrait;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
  * Base class for syndicator plugins.

--- a/src/SyndicatorPluginBase.php
+++ b/src/SyndicatorPluginBase.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\stanford_syndication;
+
+use Drupal\Component\Plugin\PluginBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeInterface;
+use Drupal\shs\StringTranslationTrait;
+
+/**
+ * Base class for syndicator plugins.
+ */
+abstract class SyndicatorPluginBase extends PluginBase implements SyndicatorInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function label(): string {
+    return $this->getPluginDefinition()['label'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setConfiguration(array $configuration) {
+    $this->configuration = $configuration;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->setConfiguration($form_state->getValues());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function insert(NodeInterface $node): void {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function update(NodeInterface $node): void {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function delete(NodeInterface $node): void {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfiguration() {
+    return $this->configuration + $this->defaultConfiguration();
+  }
+
+}

--- a/src/SyndicatorPluginManager.php
+++ b/src/SyndicatorPluginManager.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\stanford_syndication;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+
+/**
+ * Syndicator plugin manager.
+ */
+class SyndicatorPluginManager extends DefaultPluginManager {
+
+  /**
+   * Constructs SyndicatorPluginManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct(
+      'Plugin/Syndicator',
+      $namespaces,
+      $module_handler,
+      'Drupal\stanford_syndication\SyndicatorInterface',
+      'Drupal\stanford_syndication\Annotation\Syndicator'
+    );
+    $this->alterInfo('syndicator_info');
+    $this->setCacheBackend($cache_backend, 'syndicator_plugins');
+  }
+
+}

--- a/stanford_syndication.info.yml
+++ b/stanford_syndication.info.yml
@@ -1,0 +1,8 @@
+name: Stanford Syndication
+type: module
+description: Provide webhook calls to other CMS systems.
+package: Stanford
+core_version_requirement: ^9 || ^10
+configure: stanford_syndication.settings
+dependencies:
+  - drupal:node

--- a/stanford_syndication.install
+++ b/stanford_syndication.install
@@ -8,7 +8,7 @@
 /**
  * Implements hook_install().
  */
-function stanford_syndication_install($is_syncing) {
+function stanford_syndication_install() {
   $form_displays = \Drupal::entityTypeManager()
     ->getStorage('entity_form_display')
     ->loadByProperties(['targetEntityType' => 'node', 'mode' => 'default']);
@@ -16,4 +16,11 @@ function stanford_syndication_install($is_syncing) {
   foreach ($form_displays as $form) {
     $form->setComponent('syndication')->save();
   }
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function stanford_syndication_uninstall() {
+  \Drupal::state()->delete('stanford_enterprise.token');
 }

--- a/stanford_syndication.install
+++ b/stanford_syndication.install
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * stanford_syndication.install
+ */
+
+/**
+ * Implements hook_install().
+ */
+function stanford_syndication_install($is_syncing) {
+  $form_displays = \Drupal::entityTypeManager()
+    ->getStorage('entity_form_display')
+    ->loadByProperties(['targetEntityType' => 'node', 'mode' => 'default']);
+  /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $form */
+  foreach ($form_displays as $form) {
+    $form->setComponent('syndication')->save();
+  }
+}

--- a/stanford_syndication.links.menu.yml
+++ b/stanford_syndication.links.menu.yml
@@ -1,0 +1,6 @@
+stanford_syndication.settings:
+  title: 'Stanford Syndication'
+  description: 'Configure Syndication settings.'
+  parent: system.admin_config_services
+  route_name: stanford_syndication.settings
+  weight: 10

--- a/stanford_syndication.module
+++ b/stanford_syndication.module
@@ -62,9 +62,28 @@ function stanford_syndication_entity_base_field_info(EntityTypeInterface $entity
       ->setLabel(t('Syndicate Content'))
       ->setDescription(t('Send a notification to the appropriate systems about this piece of content.'))
       ->setStorageRequired(TRUE)
+      ->setInitialValue(FALSE)
+      ->setDefaultValueCallback('_stanford_syndication_default_value')
       ->setDisplayConfigurable('form', TRUE);
   }
   return $fields;
+}
+
+/**
+ * Base field default value callback.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   Node entity.
+ * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+ *   Base field definition.
+ *
+ * @return bool
+ *   Default field value.
+ */
+function _stanford_syndication_default_value(NodeInterface $node, FieldDefinitionInterface $field_definition) {
+  $account = \Drupal::currentUser();
+  $config = \Drupal::config('stanford_syndication.settings');
+  return $config->get('enabled') && $account->hasPermission('administer stanford_syndication content');
 }
 
 /**

--- a/stanford_syndication.module
+++ b/stanford_syndication.module
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for stanford_syndication module.
+ */
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\NodeInterface;
+use Drupal\stanford_syndication\Events\SyndicationEntityActionEventInterface;
+use Drupal\stanford_syndication\Events\SyndicationEntityActionEvent;
+use Drupal\stanford_syndication\Events\SyndicationEvents;
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function stanford_syndication_node_insert(NodeInterface $node) {
+  drupal_register_shutdown_function('_stanford_syndication_dispatch_event', $node, SyndicationEntityActionEventInterface::INSERT_ACTION);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function stanford_syndication_node_update(NodeInterface $node) {
+  drupal_register_shutdown_function('_stanford_syndication_dispatch_event', $node, SyndicationEntityActionEventInterface::UPDATE_ACTION);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_delete().
+ */
+function stanford_syndication_node_delete(NodeInterface $node) {
+  drupal_register_shutdown_function('_stanford_syndication_dispatch_event', $node, SyndicationEntityActionEventInterface::DELETE_ACTION);
+}
+
+/**
+ * Dispatches the syndication event.
+ *
+ * @param \Drupal\stanford_syndication\Events\SyndicationEntityActionEventInterface $event
+ *   Event to dispatch.
+ */
+function _stanford_syndication_dispatch_event(NodeInterface $node, string $action) {
+  if ($node->get('syndication')->getString() && $node->isPublished()) {
+    $event = new SyndicationEntityActionEvent($node, $action);
+    \Drupal::service('event_dispatcher')
+      ->dispatch($event, SyndicationEvents::ENTITY_ACTION);
+  }
+}
+
+/**
+ * Implements hook_entity_base_field_info().
+ */
+function stanford_syndication_entity_base_field_info(EntityTypeInterface $entity_type) {
+  $fields = [];
+  if ($entity_type->id() == 'node') {
+    $fields['syndication'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(t('Syndicate Content'))
+      ->setDescription(t('Send a notification to the appropriate systems about this piece of content.'))
+      ->setStorageRequired(TRUE)
+      ->setDisplayConfigurable('form', TRUE);
+  }
+  return $fields;
+}
+
+/**
+ * Implements hook_entity_field_access().
+ */
+function stanford_syndication_entity_field_access($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, FieldItemListInterface $items = NULL) {
+  if ($field_definition->getName() == 'syndication' && $field_definition->getTargetEntityTypeId() == 'node') {
+    $config = \Drupal::config('stanford_syndication.settings');
+    $show_field = $config->get('enabled') && $account->hasPermission('administer stanford_syndication content');
+    // Use forbidden since allowedIf will be neutral if false.
+    return AccessResult::forbiddenIf(!$show_field);
+  }
+  return AccessResult::neutral();
+}
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function stanford_syndication_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if (isset($form['syndication'])) {
+    $form['syndication_group'] = [
+      '#type' => 'details',
+      '#title' => t('Syndication Connection'),
+      '#collapsed' => FALSE,
+      '#collapsible' => TRUE,
+      '#tree' => FALSE,
+      '#group' => 'advanced',
+      '#access' => $form['syndication']['#access'],
+    ];
+    $form['syndication']['#group'] = 'syndication_group';
+  }
+}
+

--- a/stanford_syndication.permissions.yml
+++ b/stanford_syndication.permissions.yml
@@ -1,0 +1,7 @@
+administer stanford_syndication configuration:
+  title: 'Administer Syndication configuration'
+  description: 'Configure credentials and configuration for syndication integrations'
+  restrict access: true
+administer stanford_syndication content:
+  title: 'Administer Syndicated Content'
+  description: 'Enable the form checkbox to trigger the syndication webhooks'

--- a/stanford_syndication.routing.yml
+++ b/stanford_syndication.routing.yml
@@ -1,0 +1,7 @@
+stanford_syndication.settings:
+  path: '/admin/config/services/syndication'
+  defaults:
+    _title: 'Syndication Settings'
+    _form: 'Drupal\stanford_syndication\Form\SyndicationSettings'
+  requirements:
+    _permission: 'administer stanford_syndication configuration'

--- a/stanford_syndication.services.yml
+++ b/stanford_syndication.services.yml
@@ -1,0 +1,10 @@
+services:
+  stanford_syndication.event_subscriber:
+    class: Drupal\stanford_syndication\EventSubscriber\SyndicationEventSubscriber
+    arguments: ['@config.factory', '@logger.factory', '@plugin.manager.syndicator' ]
+    tags:
+      - { name: event_subscriber }
+
+  plugin.manager.syndicator:
+    class: Drupal\stanford_syndication\SyndicatorPluginManager
+    parent: default_plugin_manager

--- a/tests/src/Kernel/EventSubscriber/SyndicationEventSubscriberTest.php
+++ b/tests/src/Kernel/EventSubscriber/SyndicationEventSubscriberTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\Tests\stanford_syndication\Kernel\EventSubscriber;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\stanford_syndication\Events\SyndicationEntityActionEvent;
+use Drupal\stanford_syndication\Events\SyndicationEvents;
+use GuzzleHttp\ClientInterface;
+
+class SyndicationEventSubscriberTest extends KernelTestBase {
+
+  protected static $modules = [
+    'system',
+    'node',
+    'stanford_syndication',
+    'user',
+  ];
+
+  protected function setUp(): void {
+    parent::setUp();
+
+    $client = $this->createMock(ClientInterface::class);
+    $client->method('request')
+      ->will($this->returnCallback([$this, 'guzzleRequest']));
+    \Drupal::getContainer()->set('http_client', $client);
+
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installConfig('system');
+    NodeType::create(['type' => 'foo'])->save();
+    \Drupal::configFactory()->getEditable('stanford_syndication.settings')
+      ->set('enabled', TRUE)
+      ->set('syndicators', [
+        'stanford_enterprise' => [
+          'id' => 'stanford_enterprise',
+          'node_types' => ['foo'],
+          'webhook' => 'bar',
+        ],
+      ])->save(TRUE);
+    \Drupal::state()->set('stanford_enterprise.token', 'foobar');
+  }
+
+  public function testEventSubscriber() {
+    $this->assertNull(\Drupal::state()->get('testEventSubscriber'));
+    $node = Node::create([
+      'type' => 'foo',
+      'title' => 'bar',
+      'syndication' => TRUE,
+    ]);
+    $event = new SyndicationEntityActionEvent($node, 'insert');
+    \Drupal::service('event_dispatcher')
+      ->dispatch($event, SyndicationEvents::ENTITY_ACTION);
+    $this->assertTrue(\Drupal::state()->get('testEventSubscriber'));
+
+    \Drupal::state()->delete('testEventSubscriber');
+
+    $event = new SyndicationEntityActionEvent($node, 'update');
+    \Drupal::service('event_dispatcher')
+      ->dispatch($event, SyndicationEvents::ENTITY_ACTION);
+    $this->assertTrue(\Drupal::state()->get('testEventSubscriber'));
+
+    \Drupal::state()->delete('testEventSubscriber');
+    $event = new SyndicationEntityActionEvent($node, 'delete');
+    \Drupal::service('event_dispatcher')
+      ->dispatch($event, SyndicationEvents::ENTITY_ACTION);
+    $this->assertNull(\Drupal::state()->get('testEventSubscriber'));
+  }
+
+  public function guzzleRequest() {
+    \Drupal::state()->set('testEventSubscriber', TRUE);
+  }
+
+}

--- a/tests/src/Kernel/Form/SyndicationSettingsTest.php
+++ b/tests/src/Kernel/Form/SyndicationSettingsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\Tests\stanford_syndication\Kernel\Form;
+
+use Drupal\Core\Form\FormState;
+use Drupal\Core\Render\Element;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\NodeType;
+use Drupal\stanford_syndication\Form\SyndicationSettings;
+use GuzzleHttp\ClientInterface;
+
+class SyndicationSettingsTest extends KernelTestBase {
+
+  protected static $modules = [
+    'system',
+    'node',
+    'stanford_syndication',
+    'user',
+  ];
+
+  protected function setUp(): void {
+    parent::setUp();
+    NodeType::create(['type' => 'foo', 'name' => 'foo'])->save();
+    $this->installConfig(['system', 'stanford_syndication']);
+
+    $client = $this->createMock(ClientInterface::class);
+    $client->method('request')
+      ->will($this->returnCallback([$this, 'guzzleRequest']));
+    \Drupal::getContainer()->set('http_client', $client);
+  }
+
+  public function testForm() {
+    $builder = \Drupal::formBuilder();
+    $form_state = new FormState();
+    $form = $builder->buildForm(SyndicationSettings::class, $form_state);
+    $this->assertNotEmpty(Element::children($form['syndicators']));
+
+    $form_state->setValue([
+      'syndicators',
+      'stanford_enterprise',
+    ], ['node_types' => ['foo']]);
+    $builder->submitForm(SyndicationSettings::class, $form_state);
+    $this->assertFalse($form_state::hasAnyErrors());
+
+    $saved_config = \Drupal::config('stanford_syndication.settings')
+      ->get('syndicators.stanford_enterprise.node_types');
+    $this->assertTrue(in_array('foo', $saved_config));
+
+    $form_state->setValue([
+      'syndicators',
+      'stanford_enterprise',
+    ], ['node_types' => []]);
+    $builder->submitForm(SyndicationSettings::class, $form_state);
+    $this->assertFalse($form_state::hasAnyErrors());
+
+    $saved_config = \Drupal::config('stanford_syndication.settings')
+      ->get('syndicators');
+    $this->assertEmpty($saved_config);
+  }
+
+  public function guzzleRequest($method, $url, $options) {}
+
+}

--- a/tests/src/Unit/Plugin/Syndicator/StanfordEnterpriseTest.php
+++ b/tests/src/Unit/Plugin/Syndicator/StanfordEnterpriseTest.php
@@ -77,7 +77,7 @@ class StanfordEnterpriseTest extends UnitTestCase {
       'webhook' => 'bar',
       'access_token' => 'foo',
     ];
-    $def = [];
+    $def = ['label' => 'foo'];
     $this->plugin = StanfordEnterprise::create($container, $config, '', $def);
   }
 
@@ -113,6 +113,7 @@ class StanfordEnterpriseTest extends UnitTestCase {
   }
 
   public function testFormMethods() {
+    $this->assertNotEmpty($this->plugin->label());
     $form = [];
     $form_state = new FormState();
     $elements = $this->plugin->buildConfigurationForm($form, $form_state);

--- a/tests/src/Unit/Plugin/Syndicator/StanfordEnterpriseTest.php
+++ b/tests/src/Unit/Plugin/Syndicator/StanfordEnterpriseTest.php
@@ -41,6 +41,7 @@ class StanfordEnterpriseTest extends UnitTestCase {
     $client->method('request')
       ->will($this->returnCallback([$this, 'guzzleRequest']));
     $state = $this->createMock(StateInterface::class);
+    $state->method('get')->willReturn('foo');
 
     $nodeTypes = [
       'foo' => $this->createMock(NodeTypeInterface::class),
@@ -75,7 +76,6 @@ class StanfordEnterpriseTest extends UnitTestCase {
     $config = [
       'node_types' => ['foo'],
       'webhook' => 'bar',
-      'access_token' => 'foo',
     ];
     $def = ['label' => 'foo'];
     $this->plugin = StanfordEnterprise::create($container, $config, '', $def);

--- a/tests/src/Unit/Plugin/Syndicator/StanfordEnterpriseTest.php
+++ b/tests/src/Unit/Plugin/Syndicator/StanfordEnterpriseTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Drupal\Tests\stanford_syndication\Unit\Plugin\Syndicator;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\Core\State\StateInterface;
+use Drupal\node\NodeInterface;
+use Drupal\node\NodeTypeInterface;
+use Drupal\stanford_syndication\Plugin\Syndicator\StanfordEnterprise;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\ClientException;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Test for the syndicator plugin.
+ */
+class StanfordEnterpriseTest extends UnitTestCase {
+
+  /**
+   * Plugin to test.
+   *
+   * @var \Drupal\stanford_syndication\Plugin\Syndicator\StanfordEnterprise
+   */
+  protected $plugin;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $client = $this->createMock(ClientInterface::class);
+    $client->method('request')
+      ->will($this->returnCallback([$this, 'guzzleRequest']));
+    $state = $this->createMock(StateInterface::class);
+
+    $nodeTypes = [
+      'foo' => $this->createMock(NodeTypeInterface::class),
+      'bar' => $this->createMock(NodeTypeInterface::class),
+    ];
+
+    $entityStorage = $this->createMock(EntityStorageInterface::class);
+    $entityStorage->method('loadMultiple')->willReturn($nodeTypes);
+
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $entityTypeManager->method('getStorage')->willReturn($entityStorage);
+
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturn('Foo Bar Site');
+
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturn($config);
+
+    $request_stack = new RequestStack();
+    $request_stack->push(new Request());
+
+    $container = new ContainerBuilder();
+    $container->set('http_client', $client);
+    $container->set('state', $state);
+    $container->set('entity_type.manager', $entityTypeManager);
+    $container->set('request_stack', $request_stack);
+    $container->set('config.factory', $configFactory);
+    $container->set('string_translation', $this->getStringTranslationStub());
+
+    \Drupal::setContainer($container);
+
+    $config = [
+      'node_types' => ['foo'],
+      'webhook' => 'bar',
+      'access_token' => 'foo',
+    ];
+    $def = [];
+    $this->plugin = StanfordEnterprise::create($container, $config, '', $def);
+  }
+
+  public function testInsert() {
+    // Node is not configured to be used.
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('bundle')->willReturn('bar');
+    $this->assertNull($this->plugin->insert($node));
+
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('bundle')->willReturn('foo');
+    $this->plugin->insert($node);
+
+    $this->plugin->setConfiguration(['webhook' => 'exception'] + $this->plugin->getConfiguration());
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('bundle')->willReturn('foo');
+    $this->expectException(ClientException::class);
+    $this->plugin->insert($node);
+  }
+
+  public function testUpdate() {
+    $this->plugin->setConfiguration(['webhook' => 'exception'] + $this->plugin->getConfiguration());
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('bundle')->willReturn('foo');
+    $this->expectException(ClientException::class);
+    $this->plugin->update($node);
+  }
+
+  public function guzzleRequest($method, $uri, $options) {
+    if ($uri === 'exception') {
+      throw new ClientException('Failed', $this->createMock(RequestInterface::class));
+    }
+  }
+
+  public function testFormMethods() {
+    $form = [];
+    $form_state = new FormState();
+    $elements = $this->plugin->buildConfigurationForm($form, $form_state);
+    $this->assertTrue(in_array('foo', $elements['node_types']['#default_value']));
+
+    $this->plugin->validateConfigurationForm($form, $form_state);
+    $this->assertFalse($form_state::hasAnyErrors());
+
+    $form_state->setValue('webhook', 'foobar');
+    $form_state->setValue('node_types', ['foo']);
+    $this->assertNotEquals('foobar', $this->plugin->getConfiguration()['webhook']);
+    $this->plugin->submitConfigurationForm($form, $form_state);
+    $this->assertEquals('foobar', $this->plugin->getConfiguration()['webhook']);
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Squiz webhook plugin with extensible plugin system to add other syndication functionality if ever desired.

# Review By (Date)
- 8/18

# Review Tasks

## Setup tasks and/or behavior to test

1. `composer require su-sws/stanford_syndication:1.x-dev`
2. `drush en stanford_syndication`
3. review the settings form at `/admin/config/services/syndication`. Don't configure the form. We will do that on the dev environment.
4. Review the code. Understand the code. Love the code

There is a associated PR: https://github.com/SU-SWS/ace-sdssgryphon/pull/207
That PR will want to wait until we do some review and testing on dev. Otherwise it will disable the functionality.
